### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/hf-download.py
+++ b/hf-download.py
@@ -97,12 +97,13 @@ class HuggingFaceDownloadNode:
                 filename = get_filename(url)
                 filepath = os.path.join(dst, filename)
 
-                if "drive.google.com" in url:
+                parsed_url = urlparse(url)
+                if parsed_url.hostname == "drive.google.com":
                     gdown = gdown_download(url, dst, filepath)
                 elif url.startswith("/content/drive/MyDrive/"):
                     return url
                 else:
-                    if "huggingface.co" in url:
+                    if parsed_url.hostname == "huggingface.co":
                         if "/blob/" in url:
                             url = url.replace("/blob/", "/resolve/")
                     aria2_download(dst, filename, url)


### PR DESCRIPTION
Potential fix for [https://github.com/duskfallcrew/scripts/security/code-scanning/1](https://github.com/duskfallcrew/scripts/security/code-scanning/1)

To fix the problem, we should parse the URL and check the hostname instead of using a substring check. This ensures that the check is performed on the actual host part of the URL, preventing bypasses through embedding the string in other parts of the URL.

- Parse the URL using `urlparse` and extract the hostname.
- Check if the hostname matches "drive.google.com" or any other allowed host.
- Update the relevant lines in the `download` function to use this new method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
